### PR TITLE
Parallel workers removed from model settings file for nlp ratings v2

### DIFF
--- a/nlp-ratings-v2/model-settings.json
+++ b/nlp-ratings-v2/model-settings.json
@@ -2,6 +2,5 @@
     "implementation": "ratings.ReviewRatings",
     "parameters": {
         "uri": "./1/"
-    },
-    "parallel_workers": 0
+    }
 }


### PR DESCRIPTION
Parallel workers flag in model-settings.json is deprecated in newest versions of mlserver, so this has been removed. 